### PR TITLE
Update Ubuntu package link to Focal LTS binary

### DIFF
--- a/download.html
+++ b/download.html
@@ -98,7 +98,7 @@ permalink: download
                             <a href="https://launchpad.net/~phoerious/+archive/ubuntu/keepassxc">Official Ubuntu PPA</a>
                         </li>
                         <li class="links">
-                            <a href="https://packages.ubuntu.com/source/cosmic/keepassxc">Ubuntu package</a>
+                            <a href="https://packages.ubuntu.com/focal/keepassxc">Ubuntu package</a>
                         </li>
                         <li>
                             <code>sudo apt install keepassxc</code>


### PR DESCRIPTION
Cosmic reached End-Of-Life as an Ubuntu release this past July and thus all links to its packages lead to the generic Ubuntu 404 page. By pointing to the Focal binary release, it is certain that the link will be valid until 2025. Furthermore, pointing to the binary package page rather than the source package provides usable links for end users to download the package for manual installation if they so desire.